### PR TITLE
Enforcing sellers/buyers for reviews

### DIFF
--- a/Resell/API/NetworkManager.swift
+++ b/Resell/API/NetworkManager.swift
@@ -711,84 +711,18 @@ class NetworkManager {
             return try jsonDecoder.decode(TransactionReviewResponse.self, from: data)
         }
         
-        /// Get all transaction reviews for a seller
+        /// Get all transaction reviews for a seller. Filtering is handled server-side.
         func getReviewsForSeller(sellerId: String) async throws -> [TransactionReview] {
-            // Prefer server-side filtering when available.
-            let endpoint = "/transactionReview/?sellerId=\(sellerId)"
-            let url = try constructURL(endpoint: endpoint)
-            let request = try await createRequest(url: url, method: "GET")
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            // Some environments may not support query params on this route yet.
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-                print("⚠️ Transaction review query endpoint returned 404, trying base endpoint...")
-                return try await getReviewsForSellerFallback(sellerId: sellerId)
-            }
-            
-            do {
-                try handleResponse(data: data, response: response)
-            } catch {
-                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-                    return try await getReviewsForSellerFallback(sellerId: sellerId)
-                }
-                throw error
-            }
-            
-            // Debug: print raw response
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("⭐ Transaction reviews raw response: \(jsonString.prefix(1000))")
-            }
-            
-            var allReviews: [TransactionReview] = []
-            
-            // Try wrapped format first: { "reviews": [...] }
-            do {
-                let wrapped = try jsonDecoder.decode(TransactionReviewsResponse.self, from: data)
-                allReviews = wrapped.reviews
-            } catch {
-                print("❌ Wrapped decode failed: \(error)")
-                // Try direct array
-                do {
-                    allReviews = try jsonDecoder.decode([TransactionReview].self, from: data)
-                } catch {
-                    print("❌ Array decode failed: \(error)")
-                    throw error
-                }
-            }
-            
-            let filteredReviews = filterTransactionReviewsBySeller(allReviews, sellerId: sellerId)
-            print("⭐ Found \(filteredReviews.count) transaction reviews for seller \(sellerId) out of \(allReviews.count) total")
-            return filteredReviews
-        }
-        
-        private func getReviewsForSellerFallback(sellerId: String) async throws -> [TransactionReview] {
-            let url = try constructURL(endpoint: "/transactionReview/")
+            let url = try constructURL(endpoint: "/transactionReview/?sellerId=\(sellerId)")
             let request = try await createRequest(url: url, method: "GET")
             let (data, response) = try await URLSession.shared.data(for: request)
             try handleResponse(data: data, response: response)
             
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("⭐ Transaction reviews raw response (fallback): \(jsonString.prefix(1000))")
-            }
-            
-            var allReviews: [TransactionReview] = []
-            
             do {
-                let wrapped = try jsonDecoder.decode(TransactionReviewsResponse.self, from: data)
-                allReviews = wrapped.reviews
+                return try jsonDecoder.decode(TransactionReviewsResponse.self, from: data).reviews
             } catch {
-                print("❌ Wrapped decode failed (fallback): \(error)")
-                do {
-                    allReviews = try jsonDecoder.decode([TransactionReview].self, from: data)
-                } catch {
-                    print("❌ Array decode failed (fallback): \(error)")
-                    throw error
-                }
+                return try jsonDecoder.decode([TransactionReview].self, from: data)
             }
-            
-            let filteredReviews = filterTransactionReviewsBySeller(allReviews, sellerId: sellerId)
-            print("⭐ Found \(filteredReviews.count) transaction reviews for seller \(sellerId) out of \(allReviews.count) total (fallback)")
-            return filteredReviews
         }
         
         // MARK: - User Review Functions
@@ -849,122 +783,18 @@ class NetworkManager {
             }
         }
         
+        /// Get all user reviews for a seller. Filtering is handled server-side.
         func getUserReviewsBySeller(sellerId: String) async throws -> [UserReview] {
-            // Try with query parameter first
-            let endpoint = "/userReview/?sellerId=\(sellerId)"
-            let url = try constructURL(endpoint: endpoint)
+            let url = try constructURL(endpoint: "/userReview/?sellerId=\(sellerId)")
             let request = try await createRequest(url: url, method: "GET")
             let (data, response) = try await URLSession.shared.data(for: request)
-            
-            // Check if 404 - try without query parameter (fetch all)
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-                print("⚠️ Query parameter endpoint returned 404, trying base endpoint...")
-                return try await getUserReviewsBySellerFallback(sellerId: sellerId)
-            }
-            
-            // Handle other errors
-            do {
-                try handleResponse(data: data, response: response)
-            } catch {
-                // If handleResponse throws, try fallback
-                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-                    return try await getUserReviewsBySellerFallback(sellerId: sellerId)
-                }
-                throw error
-            }
-            
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("👤 User reviews raw response (with query): \(jsonString.prefix(10000))")
-            }
-            
-            var allReviews: [UserReview] = []
-            
-            // Try wrapped format first: { "reviews": [...] }
-            do {
-                let wrapped = try JSONDecoder().decode(UserReviewsResponse.self, from: data)
-                allReviews = wrapped.reviews
-            } catch {
-                // Try direct array
-                do {
-                    allReviews = try JSONDecoder().decode([UserReview].self, from: data)
-                } catch {
-                    print("❌ User reviews decode failed: \(error)")
-                    throw error
-                }
-            }
-            
-            let filteredReviews = filterUserReviewsBySeller(allReviews, sellerId: sellerId)
-            print("✅ Found \(filteredReviews.count) user reviews for seller \(sellerId) out of \(allReviews.count) total (query parameter worked)")
-            return filteredReviews
-        }
-        
-        private func getUserReviewsBySellerFallback(sellerId: String) async throws -> [UserReview] {
-            // Fallback: fetch all and filter client-side (if seller info is available)
-            let url = try constructURL(endpoint: "/userReview/")
-            let request = try await createRequest(url: url, method: "GET")
-            let (data, response) = try await URLSession.shared.data(for: request)
-            
-            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
-                print("⚠️ User reviews endpoint returned 404 - no reviews exist yet")
-                return []
-            }
-            
             try handleResponse(data: data, response: response)
             
-            if let jsonString = String(data: data, encoding: .utf8) {
-                print("👤 User reviews raw response (fallback): \(jsonString.prefix(1000))")
-            }
-            
-            var allReviews: [UserReview] = []
-            
-            // Try wrapped format first: { "reviews": [...] }
             do {
-                let wrapped = try JSONDecoder().decode(UserReviewsResponse.self, from: data)
-                allReviews = wrapped.reviews
+                return try jsonDecoder.decode(UserReviewsResponse.self, from: data).reviews
             } catch {
-                // Try direct array
-                do {
-                    allReviews = try JSONDecoder().decode([UserReview].self, from: data)
-                } catch {
-                    print("❌ User reviews decode failed: \(error)")
-                    throw error
-                }
+                return try jsonDecoder.decode([UserReview].self, from: data)
             }
-            
-            print("🔍 Debugging reviews for sellerId: \(sellerId)")
-            print("  Total reviews decoded with required seller info: \(allReviews.count)")
-            
-            let filteredReviews = filterUserReviewsBySeller(allReviews, sellerId: sellerId)
-            
-            print("✅ Found \(filteredReviews.count) user reviews for seller \(sellerId) out of \(allReviews.count) total")
-            return filteredReviews
-        }
-        
-        private func filterUserReviewsBySeller(_ reviews: [UserReview], sellerId: String) -> [UserReview] {
-            let filteredReviews = reviews.filter { review in
-                review.seller.firebaseUid == sellerId
-            }
-            
-            if filteredReviews.isEmpty && !reviews.isEmpty {
-                print("⚠️ UserReview seller filtering returned 0 matches for seller \(sellerId).")
-                print("⚠️ All decoded reviews include seller info, but none match this seller id.")
-            }
-            
-            return filteredReviews
-        }
-        
-        private func filterTransactionReviewsBySeller(_ reviews: [TransactionReview], sellerId: String) -> [TransactionReview] {
-            let filteredReviews = reviews.filter { review in
-                review.transaction?.seller?.firebaseUid == sellerId
-            }
-            
-            if filteredReviews.isEmpty && !reviews.isEmpty {
-                let reviewsWithSellerInfo = reviews.filter { $0.transaction?.seller != nil }.count
-                print("⚠️ TransactionReview seller filtering returned 0 matches for seller \(sellerId).")
-                print("⚠️ Reviews with transaction.seller info: \(reviewsWithSellerInfo)/\(reviews.count)")
-            }
-            
-            return filteredReviews
         }
         
         // MARK: - Other Networking Functions

--- a/Resell/API/NetworkManager.swift
+++ b/Resell/API/NetworkManager.swift
@@ -22,10 +22,9 @@ class NetworkManager {
     // MARK: - Properties
 
     #if DEBUG
-    // SWITCH
-        private let hostURL: String = Keys.prodServerURL
-    #else
         private let hostURL: String = Keys.devServerURL
+    #else
+        private let hostURL: String = Keys.prodServerURL
     #endif
     private let maxAttempts = 2
     

--- a/Resell/API/NetworkManager.swift
+++ b/Resell/API/NetworkManager.swift
@@ -22,9 +22,10 @@ class NetworkManager {
     // MARK: - Properties
 
     #if DEBUG
-        private let hostURL: String = Keys.devServerURL
-    #else
+    // SWITCH
         private let hostURL: String = Keys.prodServerURL
+    #else
+        private let hostURL: String = Keys.devServerURL
     #endif
     private let maxAttempts = 2
     
@@ -712,10 +713,26 @@ class NetworkManager {
         
         /// Get all transaction reviews for a seller
         func getReviewsForSeller(sellerId: String) async throws -> [TransactionReview] {
-            let url = try constructURL(endpoint: "/transactionReview/")
+            // Prefer server-side filtering when available.
+            let endpoint = "/transactionReview/?sellerId=\(sellerId)"
+            let url = try constructURL(endpoint: endpoint)
             let request = try await createRequest(url: url, method: "GET")
             let (data, response) = try await URLSession.shared.data(for: request)
-            try handleResponse(data: data, response: response)
+            
+            // Some environments may not support query params on this route yet.
+            if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
+                print("⚠️ Transaction review query endpoint returned 404, trying base endpoint...")
+                return try await getReviewsForSellerFallback(sellerId: sellerId)
+            }
+            
+            do {
+                try handleResponse(data: data, response: response)
+            } catch {
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 404 {
+                    return try await getReviewsForSellerFallback(sellerId: sellerId)
+                }
+                throw error
+            }
             
             // Debug: print raw response
             if let jsonString = String(data: data, encoding: .utf8) {
@@ -739,17 +756,58 @@ class NetworkManager {
                 }
             }
             
-            print("⭐ Found \(allReviews.count) total transaction reviews")
+            let filteredReviews = filterTransactionReviewsBySeller(allReviews, sellerId: sellerId)
+            print("⭐ Found \(filteredReviews.count) transaction reviews for seller \(sellerId) out of \(allReviews.count) total")
+            return filteredReviews
+        }
+        
+        private func getReviewsForSellerFallback(sellerId: String) async throws -> [TransactionReview] {
+            let url = try constructURL(endpoint: "/transactionReview/")
+            let request = try await createRequest(url: url, method: "GET")
+            let (data, response) = try await URLSession.shared.data(for: request)
+            try handleResponse(data: data, response: response)
             
-            // NOTE: Backend doesn't include seller in transaction review response
-            // For now, return all reviews. Backend should be updated to include seller info for proper filtering.
-            // TODO: Filter by seller once backend includes seller in transaction object
-            return allReviews
+            if let jsonString = String(data: data, encoding: .utf8) {
+                print("⭐ Transaction reviews raw response (fallback): \(jsonString.prefix(1000))")
+            }
+            
+            var allReviews: [TransactionReview] = []
+            
+            do {
+                let wrapped = try jsonDecoder.decode(TransactionReviewsResponse.self, from: data)
+                allReviews = wrapped.reviews
+            } catch {
+                print("❌ Wrapped decode failed (fallback): \(error)")
+                do {
+                    allReviews = try jsonDecoder.decode([TransactionReview].self, from: data)
+                } catch {
+                    print("❌ Array decode failed (fallback): \(error)")
+                    throw error
+                }
+            }
+            
+            let filteredReviews = filterTransactionReviewsBySeller(allReviews, sellerId: sellerId)
+            print("⭐ Found \(filteredReviews.count) transaction reviews for seller \(sellerId) out of \(allReviews.count) total (fallback)")
+            return filteredReviews
         }
         
         // MARK: - User Review Functions
         
         func createUserReview(review: CreateUserReviewBody) async throws -> UserReviewResponse {
+            // Refuse to create a user review without both participants.
+            // Prevents seller-less or buyer-less reviews from being persisted,
+            // which would later be unfilterable by seller on the client.
+            let trimmedBuyer = review.buyerId.trimmingCharacters(in: .whitespacesAndNewlines)
+            let trimmedSeller = review.sellerId.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmedBuyer.isEmpty, !trimmedSeller.isEmpty else {
+                logger.error("createUserReview rejected: missing buyerId or sellerId (buyer='\(trimmedBuyer)', seller='\(trimmedSeller)')")
+                throw ReviewValidationError.missingParticipants
+            }
+            guard trimmedBuyer != trimmedSeller else {
+                logger.error("createUserReview rejected: buyer and seller are the same user (\(trimmedBuyer))")
+                throw ReviewValidationError.sameBuyerAndSeller
+            }
+            
             let url = try constructURL(endpoint: "/userReview/")
             let requestData = try jsonEncoder.encode(review)
             
@@ -816,7 +874,7 @@ class NetworkManager {
             }
             
             if let jsonString = String(data: data, encoding: .utf8) {
-                print("👤 User reviews raw response (with query): \(jsonString.prefix(1000))")
+                print("👤 User reviews raw response (with query): \(jsonString.prefix(10000))")
             }
             
             var allReviews: [UserReview] = []
@@ -835,8 +893,9 @@ class NetworkManager {
                 }
             }
             
-            print("✅ Found \(allReviews.count) user reviews for seller \(sellerId) (query parameter worked)")
-            return allReviews
+            let filteredReviews = filterUserReviewsBySeller(allReviews, sellerId: sellerId)
+            print("✅ Found \(filteredReviews.count) user reviews for seller \(sellerId) out of \(allReviews.count) total (query parameter worked)")
+            return filteredReviews
         }
         
         private func getUserReviewsBySellerFallback(sellerId: String) async throws -> [UserReview] {
@@ -872,30 +931,39 @@ class NetworkManager {
                 }
             }
             
-            // Debug: Check what seller info we have
             print("🔍 Debugging reviews for sellerId: \(sellerId)")
-            var reviewsWithSeller = 0
-            for review in allReviews {
-                if review.seller != nil {
-                    reviewsWithSeller += 1
-                }
-            }
-            print("  Total reviews: \(allReviews.count), Reviews with seller info: \(reviewsWithSeller)")
+            print("  Total reviews decoded with required seller info: \(allReviews.count)")
             
-            // Filter by sellerId (only works if backend returns seller info)
-            let filteredReviews = allReviews.filter { review in
-                guard let sellerUid = review.seller?.firebaseUid else {
-                    return false
-                }
-                return sellerUid == sellerId
-            }
-            
-            if filteredReviews.isEmpty && !allReviews.isEmpty {
-                print("⚠️ WARNING: Backend is not returning 'seller' field in UserReview response. Cannot filter reviews by seller.")
-                print("⚠️ This is a backend issue - the response should include seller info for each review.")
-            }
+            let filteredReviews = filterUserReviewsBySeller(allReviews, sellerId: sellerId)
             
             print("✅ Found \(filteredReviews.count) user reviews for seller \(sellerId) out of \(allReviews.count) total")
+            return filteredReviews
+        }
+        
+        private func filterUserReviewsBySeller(_ reviews: [UserReview], sellerId: String) -> [UserReview] {
+            let filteredReviews = reviews.filter { review in
+                review.seller.firebaseUid == sellerId
+            }
+            
+            if filteredReviews.isEmpty && !reviews.isEmpty {
+                print("⚠️ UserReview seller filtering returned 0 matches for seller \(sellerId).")
+                print("⚠️ All decoded reviews include seller info, but none match this seller id.")
+            }
+            
+            return filteredReviews
+        }
+        
+        private func filterTransactionReviewsBySeller(_ reviews: [TransactionReview], sellerId: String) -> [TransactionReview] {
+            let filteredReviews = reviews.filter { review in
+                review.transaction?.seller?.firebaseUid == sellerId
+            }
+            
+            if filteredReviews.isEmpty && !reviews.isEmpty {
+                let reviewsWithSellerInfo = reviews.filter { $0.transaction?.seller != nil }.count
+                print("⚠️ TransactionReview seller filtering returned 0 matches for seller \(sellerId).")
+                print("⚠️ Reviews with transaction.seller info: \(reviewsWithSellerInfo)/\(reviews.count)")
+            }
+            
             return filteredReviews
         }
         

--- a/Resell/Models/Transaction.swift
+++ b/Resell/Models/Transaction.swift
@@ -231,8 +231,8 @@ struct UserReview: Codable, Identifiable {
     let fulfilled: Bool
     let stars: Int
     let comments: String?
-    let buyer: UserSummary?
-    let seller: UserSummary?
+    let buyer: UserSummary
+    let seller: UserSummary
     let date: String?  // Backend returns "date" field
 }
 
@@ -258,4 +258,18 @@ struct CreateUserReviewBody: Codable {
     let fulfilled: Bool
     let stars: Int
     let comments: String
+}
+
+enum ReviewValidationError: LocalizedError {
+    case missingParticipants
+    case sameBuyerAndSeller
+    
+    var errorDescription: String? {
+        switch self {
+        case .missingParticipants:
+            return "Cannot create a review without both a buyer and a seller."
+        case .sameBuyerAndSeller:
+            return "A user cannot review themselves."
+        }
+    }
 }

--- a/Resell/ViewModels/ProductDetailsViewModel.swift
+++ b/Resell/ViewModels/ProductDetailsViewModel.swift
@@ -33,27 +33,6 @@ class ProductDetailsViewModel: ObservableObject {
 
     // MARK: - Functions
 
-    func getPost(id: String) {
-        isLoading = true
-
-        Task {
-            defer { Task { @MainActor in withAnimation { isLoading = false } } }
-
-            do {
-                let postResponse = try await NetworkManager.shared.getPostByID(id: id)
-                item = postResponse.post
-                if let post = postResponse.post {
-                    images = post.images.compactMap { URL(string: $0) }
-                }
-
-                await calculateMaxImgRatio()
-                getIsSaved()
-                getSimilarPosts(id: id)
-            } catch {
-                NetworkManager.shared.logger.error("Error in ProductDetailsViewModel.getPost: \(error)")
-            }
-        }
-    }
 
     func isMyPost() -> Bool {
         if let userID = GoogleAuthManager.shared.user?.firebaseUid {
@@ -115,31 +94,10 @@ class ProductDetailsViewModel: ObservableObject {
             do {
                 let postsResponse = try await NetworkManager.shared.getSimilarPostsByID(id: id)
                 similarPosts = Array(postsResponse.posts)
-             
+                print("# of similar posts: \(similarPosts.count)")
+                
             } catch {
                 NetworkManager.shared.logger.error("Errror in ProductDetailsViewModel.getSimilarPosts: \(error)")
-            }
-        }
-    }
-
-    func getSimilarPostsNaive(post: Post) {
-        Task {
-            do {
-                // idk if this is what the endpoint even wants...
-                let postsResponse = try await NetworkManager.shared.getFilteredPosts(by: post.category != nil ? post.category! : "")
-                var otherPosts = postsResponse.posts
-                otherPosts.removeAll { $0.id == post.id }
-
-                if otherPosts.count >= 4 {
-                    similarPosts = Array(otherPosts.prefix(4))
-                } else {
-                    similarPosts = otherPosts
-                }
-
-                isLoadingImages = false
-            } catch {
-                NetworkManager.shared.logger.error("Errror in ProductDetailsViewModel.getSimilarPostsNaive: \(error)")
-                isLoadingImages = false
             }
         }
     }

--- a/Resell/ViewModels/ProfileViewModel.swift
+++ b/Resell/ViewModels/ProfileViewModel.swift
@@ -131,6 +131,7 @@ class ProfileViewModel: ObservableObject {
                 if let firebaseUid = externalUser?.firebaseUid {
                 do {
                         externalUserReviews = try await NetworkManager.shared.getUserReviewsBySeller(sellerId: firebaseUid)
+                    print("Current Firebase UID: \(firebaseUid)")
                 } catch {
                         NetworkManager.shared.logger.error("Error fetching user reviews: \(error)")
                         externalUserReviews = []

--- a/Resell/ViewModels/SearchViewModel.swift
+++ b/Resell/ViewModels/SearchViewModel.swift
@@ -74,9 +74,7 @@ class SearchViewModel: ObservableObject {
                 } else {
                     searchedItems = postsResponse.posts
                 }
-                
-                print("📝 Recent searches: \(recentlySearched)")
-                
+                                
                 if saveQuery {
                     await MainActor.run {
                         mainViewModel?.saveSearchQuery(searchText)
@@ -123,6 +121,7 @@ class SearchViewModel: ObservableObject {
         return posts
     }
     
+    // TODO: This is getting called way too much, in places it shouldn't be called.
     /// Load posts for recently searched card (fetch just enough to display)
     func loadRecentlySearchedPosts() async -> [Post] {
         if let lastFetch = lastRecentlySearchedFetchTime,
@@ -132,12 +131,8 @@ class SearchViewModel: ObservableObject {
             return cachedRecentlySearchedPosts
         }
         
-        print("🔍 Loading recently searched posts...")
-        print("📋 Recent searches count: \(recentlySearched.count)")
-        print("📋 Recent searchIds: \(recentlySearched)")
-        
+        print("Called Recent Searches")
         guard !recentlySearched.isEmpty else {
-            print("❌ No recent searches found")
             return []
         }
         

--- a/Resell/Views/Components/ReviewSection.swift
+++ b/Resell/Views/Components/ReviewSection.swift
@@ -50,7 +50,7 @@ struct UserReviewCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
                 HStack(spacing: 4) {
-                Text(review.buyer?.givenName ?? "Anonymous")
+                Text(review.buyer.givenName)
                         .font(Constants.Fonts.title3)
                         .foregroundColor(Constants.Colors.black)
                     

--- a/Resell/Views/ProductDetails/CompletedTransactionView.swift
+++ b/Resell/Views/ProductDetails/CompletedTransactionView.swift
@@ -291,7 +291,21 @@ struct CompletedTransactionView: View {
         
         Task {
             do {
-                // Create transaction review
+                // Require buyer and seller before doing anything — this prevents
+                // creating an orphan transaction review for a transaction that
+                // can't produce a valid (filterable) user review.
+                guard let buyerId = transaction.buyer?.firebaseUid,
+                      let sellerId = transaction.seller?.firebaseUid,
+                      !buyerId.isEmpty, !sellerId.isEmpty else {
+                    NetworkManager.shared.logger.error("submitReview aborted: transaction \(transaction.id) is missing buyer or seller info")
+                    await MainActor.run {
+                        isSubmitting = false
+                        errorMessage = "This transaction is missing buyer or seller info, so it can't be reviewed yet."
+                        showErrorAlert = true
+                    }
+                    return
+                }
+                
                 let reviewBody = CreateTransactionReviewBody(
                     transactionId: transaction.id,
                     stars: stars,
@@ -303,18 +317,14 @@ struct CompletedTransactionView: View {
                 
                 _ = try await NetworkManager.shared.createTransactionReview(review: reviewBody)
                 
-                // Also create a user review for the seller (only if we have buyer/seller info)
-                if let buyerId = transaction.buyer?.firebaseUid,
-                   let sellerId = transaction.seller?.firebaseUid {
-                    let userReviewBody = CreateUserReviewBody(
-                        buyerId: buyerId,
-                        sellerId: sellerId,
-                        fulfilled: true,
-                        stars: stars,
-                        comments: reviewFeedback.isEmpty ? "Great transaction!" : reviewFeedback
-                    )
-                    _ = try await NetworkManager.shared.createUserReview(review: userReviewBody)
-                }
+                let userReviewBody = CreateUserReviewBody(
+                    buyerId: buyerId,
+                    sellerId: sellerId,
+                    fulfilled: true,
+                    stars: stars,
+                    comments: reviewFeedback.isEmpty ? "Great transaction!" : reviewFeedback
+                )
+                _ = try await NetworkManager.shared.createUserReview(review: userReviewBody)
                 
                 await MainActor.run {
                     isSubmitting = false

--- a/Resell/Views/Settings/ReviewTestingView.swift
+++ b/Resell/Views/Settings/ReviewTestingView.swift
@@ -499,7 +499,18 @@ struct ReviewTestingView: View {
         }
         
         do {
-            // 1. Create transaction review
+            // Require buyer + seller up front so test data can't pollute the
+            // reviews collection with orphaned entries that lack a seller.
+            guard let buyerId = tx.buyer?.firebaseUid,
+                  let sellerId = tx.seller?.firebaseUid,
+                  !buyerId.isEmpty, !sellerId.isEmpty else {
+                await MainActor.run {
+                    isSubmitting = false
+                    submitResult = "❌ Error: transaction \(tx.id) is missing buyer or seller info — fix the test transaction before reviewing."
+                }
+                return
+            }
+            
             let reviewBody = CreateTransactionReviewBody(
                 transactionId: tx.id,
                 stars: quickStars,
@@ -511,21 +522,15 @@ struct ReviewTestingView: View {
             
             let txReviewResponse = try await NetworkManager.shared.createTransactionReview(review: reviewBody)
             
-            var userReviewResult = "skipped (no buyer/seller IDs)"
-            
-            // 2. Create user review if we have IDs
-            if let buyerId = tx.buyer?.firebaseUid,
-               let sellerId = tx.seller?.firebaseUid {
-                let userReviewBody = CreateUserReviewBody(
-                    buyerId: buyerId,
-                    sellerId: sellerId,
-                    fulfilled: true,
-                    stars: quickStars,
-                    comments: quickComment.isEmpty ? "Test review" : quickComment
-                )
-                let userResponse = try await NetworkManager.shared.createUserReview(review: userReviewBody)
-                userReviewResult = "created (id: \(userResponse.review.id))"
-            }
+            let userReviewBody = CreateUserReviewBody(
+                buyerId: buyerId,
+                sellerId: sellerId,
+                fulfilled: true,
+                stars: quickStars,
+                comments: quickComment.isEmpty ? "Test review" : quickComment
+            )
+            let userResponse = try await NetworkManager.shared.createUserReview(review: userReviewBody)
+            let userReviewResult = "created (id: \(userResponse.review.id))"
             
             await MainActor.run {
                 isSubmitting = false
@@ -537,7 +542,6 @@ struct ReviewTestingView: View {
                 """
             }
             
-            // Refresh reviews list
             await fetchReviews()
             
         } catch {


### PR DESCRIPTION
## Overview

The code originally had sellers and buyers as optional components for setting reviews, and accompanied with the backend issue this caused some problems

## Changes Made

Frontend now doesn't handle filtering and only returns posts that are mapped to the user we're currently looking at. 

https://github.com/cuappdev/resell-ios/issues/96

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stronger review submission validation: submissions now abort with a clear error if buyer or seller IDs are missing or identical.
  * UI now shows specific error alerts and halts submission when participant info is invalid.

* **Refactor**
  * Reliance on server-side seller filtering for review lists; client-side fallbacks removed for more consistent results.

* **UX**
  * Review cards reliably display the buyer’s name when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->